### PR TITLE
fix(settings): update settings and env priority

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -34,21 +34,21 @@ services:
       storage:
         condition: service_healthy
     env_file:
-      - .env
       - docker-compose.env
+      - .env
     volumes:
       - ./src:/home/app/libs
     command: migrate
-  
-  # 3.1 Create Super 
+
+  # 3.1 Create Super
   migration-user:
     image: *image
     depends_on:
       migration:
         condition: service_completed_successfully
     env_file:
-      - .env
       - docker-compose.env
+      - .env
     volumes:
       - ./src:/home/app/libs
     command: createsuperuser
@@ -66,5 +66,5 @@ services:
       - ./.log:/tmp/log
     command: devserver
     env_file:
-      - .env
       - docker-compose.env
+      - .env

--- a/{{cookiecutter.project_slug}}/settings.yaml
+++ b/{{cookiecutter.project_slug}}/settings.yaml
@@ -7,7 +7,9 @@ default:
   STATIC_ROOT: /var/www/static
   STATIC_URL: /static/
   STATIC_HOST:
-  STATICFILES_STORAGE: whitenoise.storage.CompressedStaticFilesStorage
+  STORAGES:
+    staticfiles:
+        BACKEND: whitenoise.storage.CompressedManifestStaticFilesStorage
   MEDIA_ROOT: /var/www/media
   MEDIA_URL: /media/
   ALLOWED_HOSTS:


### PR DESCRIPTION
- update whitenoise files compress settings for django 4.2+ (https://whitenoise.readthedocs.io/en/stable/django.html#add-compression-and-caching-support)
- change .env priority as the last env file has higher priority for conflict env variables